### PR TITLE
Window names

### DIFF
--- a/bin/ec2dnshelper
+++ b/bin/ec2dnshelper
@@ -49,6 +49,8 @@ try {
     die();
 }
 
+$matchedHost = null;
+
 /*
  * Replace known tags with hostnames
  * (This needs optimization!)
@@ -68,10 +70,11 @@ if ($ec2host->instances) {
             if ($instance['tag']==$ec2host->emptyTag) {
                 break;
             }
-            
-            $newArgumentValue = preg_replace('/(^.*@?)('.  preg_quote ($instance['tag'], '/') .')(:?.*$)/i', '$1'.$instance['dnsName'].'$3', $argumentValue);
+
+            $newArgumentValue = preg_replace('/(^.*@?)('.  preg_quote($instance['tag'], '/') .')(:?.*$)/i', '$1'.$instance['dnsName'].'$3', $argumentValue);
             if ($newArgumentValue!=$argumentValue) {
                 $arguments[$argumentKey] = $newArgumentValue;
+                $matchedHost = $instance['tag'];
                 break;
             }
 
@@ -84,4 +87,6 @@ if ($ec2host->instances) {
 /*
  * Return processed arguments
  */
-echo(implode(' ', $arguments)."\n");
+
+echo "export ec2args=" .  escapeshellarg(implode(' ', $arguments)). ";\n";
+echo "export ec2host=" . $matchedHost . ";\n";

--- a/bin/ec2scp
+++ b/bin/ec2scp
@@ -22,12 +22,12 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
  # Hand arguments to ec2dnshelper if we have any
  #
 if [ "$#" -ge 1 ]; then
-    scpArguments=$($DIR/ec2dnshelper $@)
+    eval $($DIR/ec2dnshelper $@)
 else
-    scpArguments=""
+    ec2args=""
 fi
 
  #
  # run scp
  #
-scp $scpArguments
+scp $ec2args

--- a/bin/ec2ssh
+++ b/bin/ec2ssh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
- # ec2ssh
- #
- # @copyright Copyright (C) 2012 fruux GmbH. All rights reserved.
- # @author Dominik Tobschall (http://fruux.com/)
+# ec2ssh
+#
+# @copyright Copyright (C) 2012 fruux GmbH. All rights reserved.
+# @author Dominik Tobschall (http://fruux.com/)
 
- #
- # Find script path
- #
+
+# Changing the window title
+setwindowtitle() {
+    printf "\033k$1\033\\"
+}
+
+#
+# Find script path
+#
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( dirname "$SOURCE" )"
 while [ -h "$SOURCE" ]
@@ -22,12 +28,17 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
  # Hand arguments to ec2dnshelper if we have any
  #
 if [ "$#" -ge 1 ]; then
-    sshArguments=$($DIR/ec2dnshelper $@)
+    eval $($DIR/ec2dnshelper $@)
+    setwindowtitle "ec2:$ec2host"
 else
-    sshArguments=""
+    ec2args=""
 fi
 
- #
- # run ssh
- #
-ssh $sshArguments
+#
+# run ssh
+#
+ssh $ec2args
+
+# back to some default.. could be wrong I suppose, but I'm not fully sure how
+# to capture the old name, and set that instead.
+setwindowtitle bash


### PR DESCRIPTION
despite the name, this should actually set the name of the window in any platform (most terminal emulators probably support this).

However, after the ssh session is completed.. I didn't know what to 'reset' the title to, so I just made it 'bash', even though this may well be wrong :S
