### PR TITLE
Setting default timezone to UTC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.0.1 (????-??-??)
+------------------
+
+* Fixed: Supressing the PHP default timezone setting if this is not set in
+  `php.ini`.
+
 2.0.0 (2015-04-29)
 ------------------
 

--- a/bin/ec2dns
+++ b/bin/ec2dns
@@ -25,6 +25,9 @@ foreach ($paths as $path) {
     }
 }
 
+/* Setting a default timezone so PHP doesn't emit any warnings */
+date_default_timezone_set('UTC');
+
 /*
  * Import namespaces
  */

--- a/bin/ec2dnshelper
+++ b/bin/ec2dnshelper
@@ -33,6 +33,9 @@ if (!isset($argv[1])) {
     die();
 }
 
+/* Setting a default timezone so PHP doesn't emit any warnings */
+date_default_timezone_set('UTC');
+
 /*
  * Import namespaces
  */

--- a/bin/ec2host
+++ b/bin/ec2host
@@ -25,6 +25,10 @@ foreach ($paths as $path) {
     }
 }
 
+/* Setting a default timezone so PHP doesn't emit any warnings */
+date_default_timezone_set('UTC');
+
+
 /*
  * Import namespaces
  */

--- a/bin/ec2updatehostsfile
+++ b/bin/ec2updatehostsfile
@@ -25,6 +25,9 @@ foreach ($paths as $path) {
     }
 }
 
+/* Setting a default timezone so PHP doesn't emit any warnings */
+date_default_timezone_set('UTC');
+
 /*
  * Import namespaces
  */


### PR DESCRIPTION
PHP will by default not have a timezone set on most systems. In those cases the ec2dns utilities will always emit a warning.
This sets the default timezone to UTC, which should not cause any other issues.
